### PR TITLE
BaseModel Introduction

### DIFF
--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -8,12 +8,11 @@ use App\Support\HasAdvancedFilter;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
+// TODO To delete when we install auditable library
 class AuditLog extends Model
 {
     use HasFactory;
     use HasAdvancedFilter;
-
-    public $table = 'audit_logs';
 
     protected $dates = [
         'created_at',

--- a/app/Models/BaseModel.php
+++ b/app/Models/BaseModel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+abstract class BaseModel extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/CaseItem.php
+++ b/app/Models/CaseItem.php
@@ -4,20 +4,13 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class CaseItem extends Model
+class CaseItem extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
-
-    public $table = 'case_items';
 
     public static $search = [
         'casenumber',

--- a/app/Models/CaseItemPriority.php
+++ b/app/Models/CaseItemPriority.php
@@ -4,24 +4,18 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class CaseItemPriority extends Model
+class CaseItemPriority extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
 
     protected $fillable = [
         'priority',
     ];
-
-    public $table = 'case_item_priorities';
 
     public $orderable = [
         'id',

--- a/app/Models/CaseItemStatus.php
+++ b/app/Models/CaseItemStatus.php
@@ -4,24 +4,17 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class CaseItemStatus extends Model
+class CaseItemStatus extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
 
     protected $fillable = [
         'status',
     ];
-
-    public $table = 'case_item_statuses';
 
     public $orderable = [
         'id',

--- a/app/Models/CaseItemType.php
+++ b/app/Models/CaseItemType.php
@@ -4,20 +4,14 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class CaseItemType extends Model
+class CaseItemType extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
-
-    public $table = 'case_item_types';
 
     protected $fillable = [
         'type',

--- a/app/Models/CaseUpdateItem.php
+++ b/app/Models/CaseUpdateItem.php
@@ -4,18 +4,13 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class CaseUpdateItem extends Model
+class CaseUpdateItem extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
 
     public const INTERNAL_RADIO = [
         'N' => 'No',
@@ -26,8 +21,6 @@ class CaseUpdateItem extends Model
         '1' => 'Outbound',
         '2' => 'Inbound',
     ];
-
-    public $table = 'case_update_items';
 
     protected $dates = [
         'created_at',

--- a/app/Models/EngagementEmailItem.php
+++ b/app/Models/EngagementEmailItem.php
@@ -4,20 +4,13 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class EngagementEmailItem extends Model
+class EngagementEmailItem extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
-
-    public $table = 'engagement_email_items';
 
     protected $fillable = [
         'email',

--- a/app/Models/EngagementInteractionDriver.php
+++ b/app/Models/EngagementInteractionDriver.php
@@ -4,18 +4,14 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class EngagementInteractionDriver extends Model
+class EngagementInteractionDriver extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
 
     protected $fillable = [
         'driver',
@@ -30,8 +26,6 @@ class EngagementInteractionDriver extends Model
         'id',
         'driver',
     ];
-
-    public $table = 'engagement_interaction_drivers';
 
     protected $dates = [
         'created_at',

--- a/app/Models/EngagementInteractionItem.php
+++ b/app/Models/EngagementInteractionItem.php
@@ -4,18 +4,14 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class EngagementInteractionItem extends Model
+class EngagementInteractionItem extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
 
     public const DIRECTION_RADIO = [
         'inbound' => 'Inbound',
@@ -31,8 +27,6 @@ class EngagementInteractionItem extends Model
         '90' => '1.5 Hours',
         '120' => '2 Hours',
     ];
-
-    public $table = 'engagement_interaction_items';
 
     public $orderable = [
         'id',

--- a/app/Models/EngagementInteractionOutcome.php
+++ b/app/Models/EngagementInteractionOutcome.php
@@ -4,18 +4,13 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class EngagementInteractionOutcome extends Model
+class EngagementInteractionOutcome extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
 
     protected $fillable = [
         'outcome',
@@ -30,8 +25,6 @@ class EngagementInteractionOutcome extends Model
         'id',
         'outcome',
     ];
-
-    public $table = 'engagement_interaction_outcomes';
 
     protected $dates = [
         'created_at',

--- a/app/Models/EngagementInteractionRelation.php
+++ b/app/Models/EngagementInteractionRelation.php
@@ -4,18 +4,13 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class EngagementInteractionRelation extends Model
+class EngagementInteractionRelation extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
 
     protected $fillable = [
         'relation',
@@ -30,8 +25,6 @@ class EngagementInteractionRelation extends Model
         'id',
         'relation',
     ];
-
-    public $table = 'engagement_interaction_relations';
 
     protected $dates = [
         'created_at',

--- a/app/Models/EngagementInteractionType.php
+++ b/app/Models/EngagementInteractionType.php
@@ -4,18 +4,13 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class EngagementInteractionType extends Model
+class EngagementInteractionType extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
 
     protected $fillable = [
         'type',
@@ -30,8 +25,6 @@ class EngagementInteractionType extends Model
         'id',
         'type',
     ];
-
-    public $table = 'engagement_interaction_types';
 
     protected $dates = [
         'created_at',

--- a/app/Models/EngagementStudentFile.php
+++ b/app/Models/EngagementStudentFile.php
@@ -4,27 +4,20 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use Spatie\MediaLibrary\HasMedia;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class EngagementStudentFile extends Model implements HasMedia
+class EngagementStudentFile extends BaseModel implements HasMedia
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
     use InteractsWithMedia;
-    use Auditable;
 
     protected $appends = [
         'file',
     ];
-
-    public $table = 'engagement_student_files';
 
     protected $fillable = [
         'description',

--- a/app/Models/EngagementTextItem.php
+++ b/app/Models/EngagementTextItem.php
@@ -4,25 +4,18 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class EngagementTextItem extends Model
+class EngagementTextItem extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
 
     public const DIRECTION_RADIO = [
         '1' => 'Inbound',
         '2' => 'Outbound',
     ];
-
-    public $table = 'engagement_text_items';
 
     protected $fillable = [
         'mobile',

--- a/app/Models/Institution.php
+++ b/app/Models/Institution.php
@@ -4,20 +4,13 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class Institution extends Model
+class Institution extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
-
-    public $table = 'institutions';
 
     public $orderable = [
         'id',

--- a/app/Models/JourneyEmailItem.php
+++ b/app/Models/JourneyEmailItem.php
@@ -4,18 +4,13 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class JourneyEmailItem extends Model
+class JourneyEmailItem extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
 
     public const ACTIVE_RADIO = [
         'N' => 'No',
@@ -29,8 +24,6 @@ class JourneyEmailItem extends Model
         '4' => 'Monthly',
         '5' => 'Annually',
     ];
-
-    public $table = 'journey_email_items';
 
     public $orderable = [
         'id',

--- a/app/Models/JourneyItem.php
+++ b/app/Models/JourneyItem.php
@@ -4,18 +4,13 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class JourneyItem extends Model
+class JourneyItem extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
 
     public const FREQUENCY_RADIO = [
         '1' => 'Once',
@@ -23,8 +18,6 @@ class JourneyItem extends Model
         '3' => 'Each Week',
         '4' => 'Each Month',
     ];
-
-    public $table = 'journey_items';
 
     public $orderable = [
         'id',

--- a/app/Models/JourneyTargetList.php
+++ b/app/Models/JourneyTargetList.php
@@ -5,17 +5,12 @@ namespace App\Models;
 use Carbon\Carbon;
 use DateTimeInterface;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class JourneyTargetList extends Model
+class JourneyTargetList extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-
-    public $table = 'journey_target_lists';
 
     public $orderable = [
         'id',

--- a/app/Models/JourneyTextItem.php
+++ b/app/Models/JourneyTextItem.php
@@ -4,18 +4,13 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class JourneyTextItem extends Model
+class JourneyTextItem extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
 
     public const ACTIVE_RADIO = [
         'N' => 'No',
@@ -29,8 +24,6 @@ class JourneyTextItem extends Model
         '4' => 'Monthly',
         '5' => 'Yearly',
     ];
-
-    public $table = 'journey_text_items';
 
     protected $dates = [
         'start',

--- a/app/Models/KbItem.php
+++ b/app/Models/KbItem.php
@@ -4,25 +4,18 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class KbItem extends Model
+class KbItem extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
 
     public const PUBLIC_RADIO = [
         'N' => 'No',
         'Y' => 'Yes',
     ];
-
-    public $table = 'kb_items';
 
     public static $search = [
         'question',

--- a/app/Models/KbItemCategory.php
+++ b/app/Models/KbItemCategory.php
@@ -4,20 +4,13 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class KbItemCategory extends Model
+class KbItemCategory extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
-
-    public $table = 'kb_item_categories';
 
     protected $fillable = [
         'category',

--- a/app/Models/KbItemQuality.php
+++ b/app/Models/KbItemQuality.php
@@ -4,20 +4,13 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class KbItemQuality extends Model
+class KbItemQuality extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
-
-    public $table = 'kb_item_qualities';
 
     protected $fillable = [
         'rating',

--- a/app/Models/KbItemStatus.php
+++ b/app/Models/KbItemStatus.php
@@ -4,20 +4,13 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class KbItemStatus extends Model
+class KbItemStatus extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
-
-    public $table = 'kb_item_statuses';
 
     protected $fillable = [
         'status',

--- a/app/Models/ProspectItem.php
+++ b/app/Models/ProspectItem.php
@@ -4,18 +4,13 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class ProspectItem extends Model
+class ProspectItem extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
 
     public const SMS_OPT_OUT_RADIO = [
         'N' => 'No',
@@ -26,8 +21,6 @@ class ProspectItem extends Model
         'N' => 'No',
         'Y' => 'Yes',
     ];
-
-    public $table = 'prospect_items';
 
     public static $search = [
         'full',

--- a/app/Models/ProspectSource.php
+++ b/app/Models/ProspectSource.php
@@ -5,17 +5,12 @@ namespace App\Models;
 use Carbon\Carbon;
 use DateTimeInterface;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class ProspectSource extends Model
+class ProspectSource extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-
-    public $table = 'prospect_sources';
 
     protected $fillable = [
         'source',

--- a/app/Models/ProspectStatus.php
+++ b/app/Models/ProspectStatus.php
@@ -4,20 +4,13 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class ProspectStatus extends Model
+class ProspectStatus extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
-
-    public $table = 'prospect_statuses';
 
     protected $fillable = [
         'status',

--- a/app/Models/RecordEnrollmentItem.php
+++ b/app/Models/RecordEnrollmentItem.php
@@ -5,17 +5,12 @@ namespace App\Models;
 use Carbon\Carbon;
 use DateTimeInterface;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class RecordEnrollmentItem extends Model
+class RecordEnrollmentItem extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-
-    public $table = 'record_enrollment_items';
 
     protected $dates = [
         'start',

--- a/app/Models/RecordProgramItem.php
+++ b/app/Models/RecordProgramItem.php
@@ -5,15 +5,10 @@ namespace App\Models;
 use Carbon\Carbon;
 use DateTimeInterface;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class RecordProgramItem extends Model
+class RecordProgramItem extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
-
-    public $table = 'record_program_items';
 
     protected $dates = [
         'created_at',

--- a/app/Models/RecordStudentItem.php
+++ b/app/Models/RecordStudentItem.php
@@ -5,12 +5,9 @@ namespace App\Models;
 use Carbon\Carbon;
 use DateTimeInterface;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class RecordStudentItem extends Model
+class RecordStudentItem extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
 
     public const DUAL_RADIO = [
@@ -37,8 +34,6 @@ class RecordStudentItem extends Model
         'N' => 'No',
         'Y' => 'Yes',
     ];
-
-    public $table = 'record_student_items';
 
     public $orderable = [
         'sisid',

--- a/app/Models/SupportPage.php
+++ b/app/Models/SupportPage.php
@@ -4,20 +4,13 @@ namespace App\Models;
 
 use Carbon\Carbon;
 use DateTimeInterface;
-use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class SupportPage extends Model
+class SupportPage extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-    use Auditable;
-
-    public $table = 'support_pages';
 
     public $orderable = [
         'id',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,7 +7,9 @@ use Carbon\Carbon;
 use DateTimeInterface;
 use App\Traits\Auditable;
 use App\Support\HasAdvancedFilter;
+use Spatie\Permission\Traits\HasRoles;
 use Illuminate\Notifications\Notifiable;
+use App\Models\Concerns\DefinesPermissions;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -20,13 +22,13 @@ class User extends Authenticatable implements HasLocalePreference
     use Notifiable;
     use SoftDeletes;
     use Auditable;
+    use HasRoles;
+    use DefinesPermissions;
 
     public const TYPE_RADIO = [
         'local' => 'Local',
         'sso' => 'SSO',
     ];
-
-    public $table = 'users';
 
     protected $hidden = [
         'remember_token',

--- a/app/Models/UserAlert.php
+++ b/app/Models/UserAlert.php
@@ -5,17 +5,12 @@ namespace App\Models;
 use Carbon\Carbon;
 use DateTimeInterface;
 use App\Support\HasAdvancedFilter;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class UserAlert extends Model
+class UserAlert extends BaseModel
 {
-    use HasFactory;
     use HasAdvancedFilter;
     use SoftDeletes;
-
-    public $table = 'user_alerts';
 
     protected $fillable = [
         'message',


### PR DESCRIPTION
This PR introduces a "BaseModel" which our existing models can extend from. This also deletes table definitions from models.

The following models don't extend the BaseModel because it's either not applicable or they are soon to be deleted from implementation of roles/permissions & auditing:

- AuditLog
- Permission
- Role
- User