### PR TITLE
[Feature] Knowledge Base HTML Output

### DIFF
--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource.php
@@ -4,7 +4,10 @@ namespace Assist\KnowledgeBase\Filament\Resources;
 
 use Filament\Resources\Resource;
 use Assist\KnowledgeBase\Models\KnowledgeBaseItem;
-use Assist\KnowledgeBase\Filament\Resources\KnowledgeBaseItemResource\Pages;
+use Assist\KnowledgeBase\Filament\Resources\KnowledgeBaseItemResource\Pages\EditKnowledgeBaseItem;
+use Assist\KnowledgeBase\Filament\Resources\KnowledgeBaseItemResource\Pages\ViewKnowledgeBaseItem;
+use Assist\KnowledgeBase\Filament\Resources\KnowledgeBaseItemResource\Pages\ListKnowledgeBaseItems;
+use Assist\KnowledgeBase\Filament\Resources\KnowledgeBaseItemResource\Pages\CreateKnowledgeBaseItem;
 
 class KnowledgeBaseItemResource extends Resource
 {
@@ -21,10 +24,10 @@ class KnowledgeBaseItemResource extends Resource
     public static function getPages(): array
     {
         return [
-            'index' => Pages\ListKnowledgeBaseItems::route('/'),
-            'create' => Pages\CreateKnowledgeBaseItem::route('/create'),
-            'view' => Pages\ViewKnowledgeBaseItem::route('/{record}'),
-            'edit' => Pages\EditKnowledgeBaseItem::route('/{record}/edit'),
+            'index' => ListKnowledgeBaseItems::route('/'),
+            'create' => CreateKnowledgeBaseItem::route('/create'),
+            'view' => ViewKnowledgeBaseItem::route('/{record}'),
+            'edit' => EditKnowledgeBaseItem::route('/{record}/edit'),
         ];
     }
 }

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/ViewKnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/ViewKnowledgeBaseItem.php
@@ -6,7 +6,7 @@ use Filament\Actions;
 use Filament\Infolists\Infolist;
 use Filament\Resources\Pages\ViewRecord;
 use Filament\Infolists\Components\TextEntry;
-use FilamentTiptapEditor\Facades\TiptapConverter;
+use Filament\Infolists\Components\ViewEntry;
 use Assist\KnowledgeBase\Filament\Resources\KnowledgeBaseItemResource;
 
 class ViewKnowledgeBaseItem extends ViewRecord
@@ -39,17 +39,16 @@ class ViewKnowledgeBaseItem extends ViewRecord
                 TextEntry::make('institution.name')
                     ->label('Institution')
                     ->translateLabel(),
-                TextEntry::make('solution')
+                ViewEntry::make('solution')
                     ->label('Solution')
                     ->translateLabel()
                     ->columnSpanFull()
-                    ->formatStateUsing(fn (string $state): string => TiptapConverter::asHTML($state))
-                    ->html(),
-                TextEntry::make('notes')
+                    ->view('filament.infolists.entries.html'),
+                ViewEntry::make('notes')
                     ->label('Notes')
                     ->translateLabel()
                     ->columnSpanFull()
-                    ->html(),
+                    ->view('filament.infolists.entries.html'),
             ]);
     }
 

--- a/resources/views/filament/infolists/entries/html.blade.php
+++ b/resources/views/filament/infolists/entries/html.blade.php
@@ -4,7 +4,7 @@
     </span>
 </dt>
 <div class="mt-2 rounded border border-gray-700 p-4">
-    <div class="prose mt-2 dark:prose-invert lg:prose-xl">
+    <div class="prose mt-2 max-w-full dark:prose-invert lg:prose-xl">
         {!! $getState() !!}
     </div>
 </div>

--- a/resources/views/filament/infolists/entries/html.blade.php
+++ b/resources/views/filament/infolists/entries/html.blade.php
@@ -1,0 +1,10 @@
+<dt class="fi-in-entry-wrp-label inline-flex items-center gap-x-3">
+    <span class="text-sm font-medium leading-6 text-gray-950 dark:text-white">
+        {{ $getLabel() }}
+    </span>
+</dt>
+<div class="mt-2 rounded border border-gray-700 p-4">
+    <div class="prose mt-2 dark:prose-invert lg:prose-xl">
+        {!! $getState() !!}
+    </div>
+</div>


### PR DESCRIPTION
This PR adds the ability to render HTML via a `ViewEntry` in our Filament infolists. This uses a Blade view under the hood which still provides the field label and provides some degree of separation from other fields.

<img width="953" alt="Screenshot 2023-08-16 at 10 52 44 PM" src="https://github.com/canyongbs/assistforhighered-2/assets/10821263/950e4644-99b9-4cf7-92f8-aef78d81447c">
