### PR TITLE
[ASSIST-133] Knowledge Base Media Management (File Restrictions) 

### DIFF
--- a/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementFilesRelationManager.php
+++ b/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementFilesRelationManager.php
@@ -23,8 +23,6 @@ class EngagementFilesRelationManager extends RelationManager
                     ->maxLength(255),
                 SpatieMediaLibraryFileUpload::make('file')
                     ->label('File')
-                    // TODO: Determine if this is needed
-                    //->visibility('private')
                     ->disk('s3')
                     ->collection('file')
                     ->required(),
@@ -38,7 +36,8 @@ class EngagementFilesRelationManager extends RelationManager
             ->columns([
                 Tables\Columns\TextColumn::make('description'),
                 SpatieMediaLibraryImageColumn::make('file')
-                    ->collection('file'),
+                    ->collection('file')
+                    ->visibility('private'),
             ])
             ->filters([
             ])

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/CreateKnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/CreateKnowledgeBaseItem.php
@@ -60,7 +60,7 @@ class CreateKnowledgeBaseItem extends CreateRecord
                     ->searchable(['name', 'code'])
                     ->preload()
                     ->exists((new Institution())->getTable(), (new Institution())->getKeyName()),
-                TiptapEditor::make('solution')
+                \App\Filament\Fields\TiptapEditor::make('solution')
                     ->label('Solution')
                     ->translateLabel()
                     ->columnSpanFull()

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/CreateKnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/CreateKnowledgeBaseItem.php
@@ -5,8 +5,8 @@ namespace Assist\KnowledgeBase\Filament\Resources\KnowledgeBaseItemResource\Page
 use Filament\Forms\Form;
 use App\Models\Institution;
 use Filament\Forms\Components\Radio;
+use App\Filament\Fields\TiptapEditor;
 use Filament\Forms\Components\Select;
-use FilamentTiptapEditor\TiptapEditor;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\CreateRecord;
 use Assist\KnowledgeBase\Models\KnowledgeBaseStatus;
@@ -60,7 +60,7 @@ class CreateKnowledgeBaseItem extends CreateRecord
                     ->searchable(['name', 'code'])
                     ->preload()
                     ->exists((new Institution())->getTable(), (new Institution())->getKeyName()),
-                \App\Filament\Fields\TiptapEditor::make('solution')
+                TiptapEditor::make('solution')
                     ->label('Solution')
                     ->translateLabel()
                     ->columnSpanFull()

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/EditKnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/EditKnowledgeBaseItem.php
@@ -6,8 +6,8 @@ use Filament\Actions;
 use Filament\Forms\Form;
 use App\Models\Institution;
 use Filament\Forms\Components\Radio;
+use App\Filament\Fields\TiptapEditor;
 use Filament\Forms\Components\Select;
-use FilamentTiptapEditor\TiptapEditor;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
 use Assist\KnowledgeBase\Models\KnowledgeBaseStatus;
@@ -61,7 +61,7 @@ class EditKnowledgeBaseItem extends EditRecord
                     ->searchable(['name', 'code'])
                     ->preload()
                     ->exists((new Institution())->getTable(), (new Institution())->getKeyName()),
-                \App\Filament\Fields\TiptapEditor::make('solution')
+                TiptapEditor::make('solution')
                     ->label('Solution')
                     ->translateLabel()
                     ->columnSpanFull()

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/EditKnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/EditKnowledgeBaseItem.php
@@ -61,7 +61,7 @@ class EditKnowledgeBaseItem extends EditRecord
                     ->searchable(['name', 'code'])
                     ->preload()
                     ->exists((new Institution())->getTable(), (new Institution())->getKeyName()),
-                TiptapEditor::make('solution')
+                \App\Filament\Fields\TiptapEditor::make('solution')
                     ->label('Solution')
                     ->translateLabel()
                     ->columnSpanFull()

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementFilesRelationManager.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementFilesRelationManager.php
@@ -23,8 +23,6 @@ class EngagementFilesRelationManager extends RelationManager
                     ->maxLength(255),
                 SpatieMediaLibraryFileUpload::make('file')
                     ->label('File')
-                    // TODO: Determine if this is needed
-                    //->visibility('private')
                     ->disk('s3')
                     ->collection('file')
                     ->required(),
@@ -38,7 +36,8 @@ class EngagementFilesRelationManager extends RelationManager
             ->columns([
                 Tables\Columns\TextColumn::make('description'),
                 SpatieMediaLibraryImageColumn::make('file')
-                    ->collection('file'),
+                    ->collection('file')
+                    ->visibility('private'),
             ])
             ->filters([
             ])

--- a/app-modules/prospect/src/Models/Prospect.php
+++ b/app-modules/prospect/src/Models/Prospect.php
@@ -24,7 +24,6 @@ use Assist\Engagement\Models\EngagementFileEntities;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Assist\Notifications\Models\Contracts\Subscribable;
-use Assist\Prospect\Database\Factories\ProspectFactory;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Notifications\DatabaseNotificationCollection;
 use Assist\Audit\Models\Concerns\Auditable as AuditableTrait;
@@ -71,12 +70,12 @@ use Assist\Engagement\Models\Concerns\HasManyMorphedEngagementResponses;
  * @property-read int|null $notifications_count
  * @property-read Collection<int, ServiceRequest> $serviceRequests
  * @property-read int|null $service_requests_count
- * @property-read ProspectSource $source
- * @property-read ProspectStatus $status
+ * @property-read \Assist\Prospect\Models\ProspectSource $source
+ * @property-read \Assist\Prospect\Models\ProspectStatus $status
  * @property-read Collection<int, Task> $tasks
  * @property-read int|null $tasks_count
  *
- * @method static ProspectFactory factory($count = null, $state = [])
+ * @method static \Assist\Prospect\Database\Factories\ProspectFactory factory($count = null, $state = [])
  * @method static Builder|Prospect newModelQuery()
  * @method static Builder|Prospect newQuery()
  * @method static Builder|Prospect onlyTrashed()

--- a/app-modules/prospect/src/Models/Prospect.php
+++ b/app-modules/prospect/src/Models/Prospect.php
@@ -24,6 +24,7 @@ use Assist\Engagement\Models\EngagementFileEntities;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Assist\Notifications\Models\Contracts\Subscribable;
+use Assist\Prospect\Database\Factories\ProspectFactory;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Notifications\DatabaseNotificationCollection;
 use Assist\Audit\Models\Concerns\Auditable as AuditableTrait;
@@ -70,12 +71,12 @@ use Assist\Engagement\Models\Concerns\HasManyMorphedEngagementResponses;
  * @property-read int|null $notifications_count
  * @property-read Collection<int, ServiceRequest> $serviceRequests
  * @property-read int|null $service_requests_count
- * @property-read \Assist\Prospect\Models\ProspectSource $source
- * @property-read \Assist\Prospect\Models\ProspectStatus $status
+ * @property-read ProspectSource $source
+ * @property-read ProspectStatus $status
  * @property-read Collection<int, Task> $tasks
  * @property-read int|null $tasks_count
  *
- * @method static \Assist\Prospect\Database\Factories\ProspectFactory factory($count = null, $state = [])
+ * @method static ProspectFactory factory($count = null, $state = [])
  * @method static Builder|Prospect newModelQuery()
  * @method static Builder|Prospect newQuery()
  * @method static Builder|Prospect onlyTrashed()
@@ -183,7 +184,7 @@ class Prospect extends BaseModel implements Auditable, Subscribable
             table: 'engagement_file_entities',
             foreignPivotKey: 'entity_id',
             relatedPivotKey: 'engagement_file_id',
-            relation: 'prospects',
+            relation: 'engagementFiles',
         )
             ->using(EngagementFileEntities::class)
             ->withTimestamps();

--- a/app/Filament/Actions/MediaAction.php
+++ b/app/Filament/Actions/MediaAction.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Filament\Actions;
+
+use Illuminate\Support\Str;
+use Illuminate\Support\HtmlString;
+use Filament\Forms\Components\Hidden;
+use Intervention\Image\Facades\Image;
+use Filament\Forms\ComponentContainer;
+use FilamentTiptapEditor\TiptapEditor;
+use Illuminate\Support\Facades\Storage;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\BaseFileUpload;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+use FilamentTiptapEditor\Actions\MediaAction as BaseMediaAction;
+
+class MediaAction extends BaseMediaAction
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this
+            ->mountUsing(function (TiptapEditor $component, ComponentContainer $form, array $arguments) {
+                $source = $arguments['src'] !== ''
+                    ? $component->getDirectory() . Str::of($arguments['src'])
+                        ->after($component->getDirectory())
+                    : null;
+
+                $form->fill([
+                    'src' => $source,
+                    'alt' => $arguments['alt'] ?? '',
+                    'title' => $arguments['title'] ?? '',
+                    'width' => $arguments['width'] ?? '',
+                    'height' => $arguments['height'] ?? '',
+                ]);
+            })->form(function (TiptapEditor $component) {
+                return [
+                    FileUpload::make('src')
+                        ->label(__('filament-tiptap-editor::media-modal.labels.file'))
+                        ->disk($component->getDisk())
+                        ->directory($component->getDirectory())
+                        ->visibility(config('filament-tiptap-editor.visibility'))
+                        ->preserveFilenames(config('filament-tiptap-editor.preserve_file_names'))
+                        ->acceptedFileTypes($component->getAcceptedFileTypes())
+                        ->maxFiles(1)
+                        ->maxSize($component->getMaxFileSize())
+                        ->imageCropAspectRatio(config('filament-tiptap-editor.image_crop_aspect_ratio'))
+                        ->imageResizeTargetWidth(config('filament-tiptap-editor.image_resize_target_width'))
+                        ->imageResizeTargetHeight(config('filament-tiptap-editor.image_resize_target_height'))
+                        ->required()
+                        ->reactive()
+                        ->afterStateUpdated(function (TemporaryUploadedFile $state, callable $set) {
+                            if (Str::contains($state->getMimeType(), 'image')) {
+                                $set('type', 'image');
+                            } else {
+                                $set('type', 'document');
+                            }
+                        })
+                        ->saveUploadedFileUsing(function (BaseFileUpload $component, TemporaryUploadedFile $file, callable $set) {
+                            $filename = $component->shouldPreserveFilenames() ? pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME) : Str::uuid();
+
+                            $storeMethod = $component->getVisibility() === 'public' ? 'storePubliclyAs' : 'storeAs';
+
+                            if (Storage::disk($component->getDiskName())->exists(ltrim($component->getDirectory() . '/' . $filename . '.' . $file->getClientOriginalExtension(), '/'))) {
+                                $filename = $filename . '-' . time();
+                            }
+
+                            if (Str::contains($file->getMimeType(), 'image')) {
+                                if (config('filesystems.disks.s3.driver') === 's3') {
+                                    $image = Image::make($file->readStream());
+                                } else {
+                                    $image = Image::make($file->getRealPath());
+                                }
+
+                                $set('width', $image->getWidth());
+                                $set('height', $image->getHeight());
+                            }
+
+                            $upload = $file->{$storeMethod}($component->getDirectory(), $filename . '.' . $file->getClientOriginalExtension(), $component->getDiskName());
+
+                            return $component->getVisibility() === 'private' ? Storage::disk($component->getDiskName())->temporaryUrl($upload, now()->addMinutes(5)) : Storage::disk($component->getDiskName())->url($upload);
+                            //return Storage::disk($component->getDiskName())->url($upload);
+                        }),
+                    TextInput::make('link_text')
+                        ->label(__('filament-tiptap-editor::media-modal.labels.link_text'))
+                        ->required()
+                        ->visible(fn (callable $get) => $get('type') == 'document'),
+                    TextInput::make('alt')
+                        ->label(__('filament-tiptap-editor::media-modal.labels.alt'))
+                        ->hidden(fn (callable $get) => $get('type') == 'document')
+                        ->helperText(new HtmlString('<span class="text-xs"><a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener" class="underline text-primary-500 hover:text-primary-600 focus:text-primary-600">' . __('filament-tiptap-editor::media-modal.labels.alt_helper_text') . '</a></span>')),
+                    TextInput::make('title')
+                        ->label(__('filament-tiptap-editor::media-modal.labels.title')),
+                    Hidden::make('width'),
+                    Hidden::make('height'),
+                    Hidden::make('type')
+                        ->default('document'),
+                ];
+            })->action(function (TiptapEditor $component, $data) {
+                $source = str_starts_with($data['src'], 'http')
+                    ? $data['src']
+                    : config('app.url') . Storage::url($data['src']);
+
+                $component->getLivewire()->dispatch(
+                    'insert-media',
+                    statePath: $component->getStatePath(),
+                    media: [
+                        'src' => $source,
+                        'alt' => $data['alt'] ?? null,
+                        'title' => $data['title'],
+                        'width' => $data['width'],
+                        'height' => $data['height'],
+                        'link_text' => $data['link_text'] ?? null,
+                    ],
+                );
+            });
+    }
+}

--- a/app/Filament/Fields/TiptapEditor.php
+++ b/app/Filament/Fields/TiptapEditor.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Filament\Fields;
+
+use Illuminate\Support\Facades\Storage;
+use FilamentTiptapEditor\TiptapEditor as BaseTiptapEditor;
+
+class TiptapEditor extends BaseTiptapEditor
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->afterStateHydrated(function (BaseTiptapEditor $component, string | array | null $state) {
+            if (! $state) {
+                $component->state('<p></p>');
+            }
+
+            $state = $this->decodeMediaInState($component, $state);
+
+            $component->state($state);
+
+            $component->state($component->getHTML());
+        });
+
+        $this->dehydrateStateUsing(function (BaseTiptapEditor $component, string | array | null $state) {
+            $state = $this->encodeMediaInState($component, $state);
+
+            $component->state($state);
+
+            if ($state && $this->expectsJSON()) {
+                return $component->getJSON();
+            }
+
+            if ($state && $this->expectsText()) {
+                return $component->getText();
+            }
+
+            return $state;
+        });
+    }
+
+    protected function decodeMediaInState(BaseTiptapEditor $component, string | array | null $state): string | array | null
+    {
+        $regex = '/{{media\|path:([^}]*)}}/';
+
+        preg_match($regex, $state, $matches, PREG_OFFSET_CAPTURE);
+
+        if (! empty($matches)) {
+            $path = $matches[1][0];
+
+            $temporaryUrl = Storage::disk($component->getDisk())->temporaryUrl($path, now()->addMinutes(5));
+
+            $urlString = $matches[0][0];
+
+            $state = str_replace($urlString, $temporaryUrl, $state);
+        }
+
+        return $state;
+    }
+
+    protected function encodeMediaInState(BaseTiptapEditor $component, string | array | null $state): string | array | null
+    {
+        $diskConfig = Storage::disk($component->getDisk())->getConfig();
+
+        $bucket = isset($diskConfig['bucket']) ? "\/{$diskConfig['bucket']}" : null;
+
+        $regex = "/<img.*src=\"?'?(https?:\/\/[^\/]*{$bucket}(\/[^?]*)\??[^\"']*(?=\"?'?))/";
+
+        preg_match($regex, $state, $matches, PREG_OFFSET_CAPTURE);
+
+        if (! empty($matches)) {
+            $path = $matches[2][0];
+
+            $urlString = $matches[1][0];
+
+            $state = str_replace($urlString, "{{media|path:{$path}}}", $state);
+        }
+
+        return $state;
+    }
+}

--- a/app/Filament/Fields/TiptapEditor.php
+++ b/app/Filament/Fields/TiptapEditor.php
@@ -3,7 +3,9 @@
 namespace App\Filament\Fields;
 
 use App\Support\TiptapMediaEncoder;
+use App\Filament\Actions\MediaAction;
 use FilamentTiptapEditor\TiptapEditor as BaseTiptapEditor;
+use FilamentTiptapEditor\Actions\MediaAction as FilamentTiptapEditorMediaAction;
 
 class TiptapEditor extends BaseTiptapEditor
 {
@@ -11,18 +13,27 @@ class TiptapEditor extends BaseTiptapEditor
     {
         parent::setUp();
 
+        $this->actions = collect($this->actions)
+            ->filter(function ($action) {
+                return $action::class !== FilamentTiptapEditorMediaAction::class;
+            })
+            ->push(MediaAction::make())
+            ->toArray();
+
         $this->afterStateHydrated(function (BaseTiptapEditor $component, string | array | null $state) {
             if (! $state) {
                 $component->state('<p></p>');
             }
 
-            $component->state(TiptapMediaEncoder::decode($component, $state));
+            if (! empty($state)) {
+                $component->state(TiptapMediaEncoder::decode($state));
+            }
 
             $component->state($component->getHTML());
         });
 
         $this->dehydrateStateUsing(function (BaseTiptapEditor $component, string | array | null $state) {
-            $state = TiptapMediaEncoder::encode($component, $state);
+            $state = TiptapMediaEncoder::encode($component->getDisk(), $state);
 
             $component->state($state);
 

--- a/app/Support/TiptapMediaEncoder.php
+++ b/app/Support/TiptapMediaEncoder.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Storage;
+use FilamentTiptapEditor\TiptapEditor as BaseTiptapEditor;
+
+class TiptapMediaEncoder
+{
+    public static function encode(BaseTiptapEditor $component, string | array | null $state): array|string|null
+    {
+        if (gettype($state) === 'string') {
+            $diskConfig = Storage::disk($component->getDisk())->getConfig();
+
+            $bucket = isset($diskConfig['bucket']) ? "\/{$diskConfig['bucket']}" : null;
+
+            $regex = "/<img.*src=\"?'?(https?:\/\/[^\/]*{$bucket}(\/[^?]*)\??[^\"']*(?=\"?'?))/";
+
+            preg_match($regex, $state, $matches, PREG_OFFSET_CAPTURE);
+
+            if (! empty($matches)) {
+                $path = $matches[2][0];
+
+                $urlString = $matches[1][0];
+
+                $state = str_replace($urlString, "{{media|path:{$path}}}", $state);
+            }
+        }
+
+        return $state;
+    }
+
+    public static function decode(BaseTiptapEditor $component, string | array | null $state): array|string|null
+    {
+        if (gettype($state) === 'string') {
+            $regex = '/{{media\|path:([^}]*)}}/';
+
+            preg_match($regex, $state, $matches, PREG_OFFSET_CAPTURE);
+
+            if (! empty($matches)) {
+                $path = $matches[1][0];
+
+                $temporaryUrl = Storage::disk($component->getDisk())->temporaryUrl($path, now()->addMinutes(5));
+
+                $urlString = $matches[0][0];
+
+                $state = str_replace($urlString, $temporaryUrl, $state);
+            }
+        }
+
+        return $state;
+    }
+}

--- a/app/Support/TiptapMediaEncoder.php
+++ b/app/Support/TiptapMediaEncoder.php
@@ -3,14 +3,13 @@
 namespace App\Support;
 
 use Illuminate\Support\Facades\Storage;
-use FilamentTiptapEditor\TiptapEditor as BaseTiptapEditor;
 
 class TiptapMediaEncoder
 {
-    public static function encode(BaseTiptapEditor $component, string | array | null $state): array|string|null
+    public static function encode(string $disk, string | array | null $state): array|string|null
     {
         if (gettype($state) === 'string') {
-            $diskConfig = Storage::disk($component->getDisk())->getConfig();
+            $diskConfig = Storage::disk($disk)->getConfig();
 
             $bucket = isset($diskConfig['bucket']) ? "\/{$diskConfig['bucket']}" : null;
 
@@ -23,24 +22,25 @@ class TiptapMediaEncoder
 
                 $urlString = $matches[1][0];
 
-                $state = str_replace($urlString, "{{media|path:{$path}}}", $state);
+                $state = str_replace($urlString, "{{media|path:{$path};disk:{$disk};}}", $state);
             }
         }
 
         return $state;
     }
 
-    public static function decode(BaseTiptapEditor $component, string | array | null $state): array|string|null
+    public static function decode(string | array | null $state): array|string|null
     {
         if (gettype($state) === 'string') {
-            $regex = '/{{media\|path:([^}]*)}}/';
+            $regex = '/{{media\|path:([^}]*);disk:([^}]*);}}/';
 
             preg_match($regex, $state, $matches, PREG_OFFSET_CAPTURE);
 
             if (! empty($matches)) {
                 $path = $matches[1][0];
+                $disk = $matches[2][0];
 
-                $temporaryUrl = Storage::disk($component->getDisk())->temporaryUrl($path, now()->addMinutes(5));
+                $temporaryUrl = Storage::disk($disk)->temporaryUrl($path, now()->addMinutes(5));
 
                 $urlString = $matches[0][0];
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^8.2",
         "ext-pdo": "*",
-        "awcodes/filament-tiptap-editor": "^3.0@beta",
+        "awcodes/filament-tiptap-editor": "dev-feature/insert-media-signed-urls-3.x",
         "bvtterfly/model-state-machine": "^0.3.0",
         "canyon-gbs/assist-data-model": "*",
         "canyon-gbs/audit": "*",
@@ -176,6 +176,10 @@
         {
             "type": "vcs",
             "url": "https://github.com/canyongbs/laravel-auditing"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/Orrison/filament-tiptap-editor.git"
         }
     ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f006b859e6937c94d3aacd8be220f714",
+    "content-hash": "71e2dd093d28342dcc162cba931969d2",
     "packages": [
         {
             "name": "awcodes/filament-tiptap-editor",
-            "version": "v3.0.0-beta.1",
+            "version": "dev-feature/insert-media-signed-urls-3.x",
             "source": {
                 "type": "git",
-                "url": "https://github.com/awcodes/filament-tiptap-editor.git",
-                "reference": "9ec2dceec29d5fc06245341633291136aceb8a99"
+                "url": "https://github.com/Orrison/filament-tiptap-editor.git",
+                "reference": "2be3f158b2985cbe0c01c1090ca4f3dd5293ae09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/awcodes/filament-tiptap-editor/zipball/9ec2dceec29d5fc06245341633291136aceb8a99",
-                "reference": "9ec2dceec29d5fc06245341633291136aceb8a99",
+                "url": "https://api.github.com/repos/Orrison/filament-tiptap-editor/zipball/2be3f158b2985cbe0c01c1090ca4f3dd5293ae09",
+                "reference": "2be3f158b2985cbe0c01c1090ca4f3dd5293ae09",
                 "shasum": ""
             },
             "require": {
-                "filament/filament": "^3.0@beta",
+                "filament/filament": "^3.0",
                 "intervention/image": "^2.7",
                 "php": "^8.1",
                 "spatie/laravel-package-tools": "^1.9.2",
@@ -29,8 +29,8 @@
             },
             "require-dev": {
                 "laravel/pint": "^1.0",
-                "nunomaduro/collision": "^6.0|^7.0",
-                "orchestra/testbench": "^7.0|^8.0",
+                "nunomaduro/collision": "^7.0",
+                "orchestra/testbench": "^8.0",
                 "spatie/laravel-ray": "^1.26"
             },
             "type": "package",
@@ -52,7 +52,16 @@
                     "FilamentTiptapEditor\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "FilamentTiptapEditor\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "pint": [
+                    "vendor/bin/pint"
+                ]
+            },
             "license": [
                 "MIT"
             ],
@@ -73,16 +82,15 @@
                 "wysiwyg"
             ],
             "support": {
-                "issues": "https://github.com/awcodes/filament-tiptap-editor/issues",
-                "source": "https://github.com/awcodes/filament-tiptap-editor/tree/v3.0.0-beta.1"
+                "source": "https://github.com/Orrison/filament-tiptap-editor/tree/feature/insert-media-signed-urls-3.x"
             },
             "funding": [
                 {
-                    "url": "https://github.com/awcodes",
-                    "type": "github"
+                    "type": "github",
+                    "url": "https://github.com/awcodes"
                 }
             ],
-            "time": "2023-08-06T17:02:35+00:00"
+            "time": "2023-09-07T00:07:18+00:00"
         },
         {
             "name": "aws/aws-crt-php",
@@ -16117,7 +16125,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "awcodes/filament-tiptap-editor": 10,
         "livewire/livewire": 10
     },
     "prefer-stable": true,

--- a/config/filament-tiptap-editor.php
+++ b/config/filament-tiptap-editor.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Filament\Actions\MediaAction;
+
 return [
     'direction' => 'ltr',
     'max_content_width' => '5xl',
@@ -45,7 +47,7 @@ return [
     |--------------------------------------------------------------------------
     |
     */
-    'media_action' => FilamentTiptapEditor\Actions\MediaAction::class,
+    'media_action' => MediaAction::class,
     //    'media_action' => Awcodes\Curator\Actions\MediaAction::class,
     'link_action' => FilamentTiptapEditor\Actions\LinkAction::class,
 
@@ -75,7 +77,7 @@ return [
     'accepted_file_types' => ['image/jpeg', 'image/png', 'image/webp', 'image/svg+xml', 'application/pdf'],
     'disk' => 's3',
     'directory' => 'kb-images',
-    'visibility' => 'public',
+    'visibility' => 'private',
     'preserve_file_names' => false,
     'max_file_size' => 2042,
     'image_crop_aspect_ratio' => null,

--- a/config/filament-tiptap-editor.php
+++ b/config/filament-tiptap-editor.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Filament\Actions\MediaAction;
+use FilamentTiptapEditor\Actions\MediaAction;
 
 return [
     'direction' => 'ltr',

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -5,7 +5,7 @@ return [
      * The disk on which to store added files and derived images by default. Choose
      * one or more of the disks you've configured in config/filesystems.php.
      */
-    'disk_name' => env('MEDIA_DISK', 'public'),
+    'disk_name' => env('MEDIA_DISK', 's3'),
 
     /*
      * The maximum file size of an item in bytes.

--- a/resources/views/filament/infolists/entries/html.blade.php
+++ b/resources/views/filament/infolists/entries/html.blade.php
@@ -1,3 +1,4 @@
+@php use App\Support\TiptapMediaEncoder; @endphp
 <dt class="fi-in-entry-wrp-label inline-flex items-center gap-x-3">
     <span class="text-sm font-medium leading-6 text-gray-950 dark:text-white">
         {{ $getLabel() }}
@@ -5,6 +6,6 @@
 </dt>
 <div class="mt-2 rounded border border-gray-700 p-4">
     <div class="prose mt-2 max-w-full dark:prose-invert lg:prose-xl">
-        {!! $getState() !!}
+        {!! TiptapMediaEncoder::decode($getState()) !!}
     </div>
 </div>


### PR DESCRIPTION
https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/133/

This makes changes to ensure that both the media of EngagementFiles and KnowledgeBaseItems media are private.

Changes are made to make the Tiptap Editor work in Create, Edit, and View with private images by retrieving a temporary signed URL when the content is loaded and decoded.
Currently, this change is blocked by an issue in the JS code for the TipTap editor, but I have submitted a fix to the repo that I have high hopes of merging in.
https://github.com/awcodes/filament-tiptap-editor/pull/160
In the meantime, I have pointed the dependency at my fork.