### PR TITLE
[Bugfix] Role unique key constraint fix

### DIFF
--- a/app-modules/authorization/database/factories/RoleFactory.php
+++ b/app-modules/authorization/database/factories/RoleFactory.php
@@ -2,17 +2,18 @@
 
 namespace Assist\Authorization\Database\Factories;
 
+use Assist\Authorization\Models\Role;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Assist\Authorization\Models\Role>
+ * @extends Factory<Role>
  */
 class RoleFactory extends Factory
 {
     public function definition(): array
     {
         return [
-            'name' => fake()->word,
+            'name' => fake()->text(25),
             'guard_name' => fake()->randomElement(['web', 'api']),
         ];
     }

--- a/composer.json
+++ b/composer.json
@@ -146,6 +146,10 @@
         "checks": [
             "@lint-dryrun",
             "@larastan"
+        ],
+        "ci": [
+            "rm -rf ./vendor",
+            "composer install"
         ]
     },
     "extra": {


### PR DESCRIPTION
Reduces the chance of conflict with Unique key constraint violation that is randomly causing some of our tests to fail.

Also adds a `composer ci` command to dump the `vendor` folder and re-install. Useful for moving between branches where the module deps have changed.